### PR TITLE
Add 'deferRender' flag to DataTables, to speed up page load.

### DIFF
--- a/pprxweb/scorebrowser/static/scores-1.2.14.js
+++ b/pprxweb/scorebrowser/static/scores-1.2.14.js
@@ -275,6 +275,7 @@ $(document).ready(function () {
 	var scoresTable = $('#scores').DataTable({
 		data: scores,
 		responsive: true,
+		deferRender: true,
 		columns: [
 			{ data: '0', visible: false }, // white visibility
 			{ data: '1', visible: false }, // gold visibility

--- a/pprxweb/scorebrowser/templates/scorebrowser/scores.html
+++ b/pprxweb/scorebrowser/templates/scorebrowser/scores.html
@@ -7,7 +7,7 @@
 
 {% block scripts %}
 	<script src="https://cdn.datatables.net/1.13.1/js/jquery.dataTables.min.js"></script>
-	<script src="{% static 'scores-1.2.13.js' %}"></script>
+	<script src="{% static 'scores-1.2.14.js' %}"></script>
 	<link rel="stylesheet" href="https://cdn.datatables.net/1.13.1/css/jquery.dataTables.min.css">
 {% endblock %}
 


### PR DESCRIPTION
Beware; I have not really tested this. (I made the edit live in Chrome Dev Tools as a proof of concept, but I do not actually have the project running locally for testing purposes.)