### PR TITLE
Bump the pip group across 1 directory with 2 updates

### DIFF
--- a/pprxweb/requirements.in
+++ b/pprxweb/requirements.in
@@ -1,5 +1,5 @@
 cir-model==0.2.0
-django==4.2.25
+django==4.2.26
 django-environ==0.9.0
 matplotlib==3.9.2
 mysqlclient==2.2.4

--- a/pprxweb/requirements.txt
+++ b/pprxweb/requirements.txt
@@ -16,13 +16,13 @@ contourpy==1.3.0
     # via matplotlib
 cycler==0.12.1
     # via matplotlib
-django==4.2.25
+django==4.2.26
     # via -r requirements.in
 django-environ==0.9.0
     # via -r requirements.in
 fonttools==4.54.0
     # via matplotlib
-idna==2.10
+idna==3.7
     # via requests
 joblib==1.4.2
     # via scikit-learn
@@ -70,8 +70,6 @@ threadpoolctl==3.5.0
     # via scikit-learn
 typing-extensions==4.4.0
     # via -r requirements.in
-tzdata==2025.2
-    # via django
 urllib3==2.5.0
     # via
     #   -r requirements.in


### PR DESCRIPTION
Bumps the pip group with 2 updates in the /pprxweb directory: [django](https://github.com/django/django) and [idna](https://github.com/kjd/idna).


Updates `django` from 4.2.25 to 4.2.26
- [Commits](https://github.com/django/django/compare/4.2.25...4.2.26)

Updates `idna` from 2.10 to 3.7
- [Release notes](https://github.com/kjd/idna/releases)
- [Changelog](https://github.com/kjd/idna/blob/master/HISTORY.rst)
- [Commits](https://github.com/kjd/idna/compare/v2.10...v3.7)

---
updated-dependencies:
- dependency-name: django dependency-version: 4.2.26 dependency-type: direct:production dependency-group: pip
- dependency-name: idna dependency-version: '3.7' dependency-type: indirect dependency-group: pip ...