### PR TITLE
Bump urllib3 in /pprxweb in the pip group across 1 directory

### DIFF
--- a/pprxweb/requirements.in
+++ b/pprxweb/requirements.in
@@ -10,5 +10,5 @@ six==1.16.0
 scipy==1.14.1
 sqlparse==0.5.0
 typing-extensions==4.4.0
-urllib3==2.5.0
+urllib3==2.6.3
 whitenoise

--- a/pprxweb/requirements.txt
+++ b/pprxweb/requirements.txt
@@ -52,9 +52,7 @@ threadpoolctl==3.5.0
     # via scikit-learn
 typing-extensions==4.4.0
     # via -r requirements.in
-tzdata==2025.2
-    # via django
-urllib3==2.5.0
+urllib3==2.6.3
     # via
     #   -r requirements.in
     #   requests

--- a/pprxweb/requirements.txt
+++ b/pprxweb/requirements.txt
@@ -52,6 +52,8 @@ threadpoolctl==3.5.0
     # via scikit-learn
 typing-extensions==4.4.0
     # via -r requirements.in
+tzdata==2025.2
+    # via django
 urllib3==2.6.3
     # via
     #   -r requirements.in


### PR DESCRIPTION
Bumps the pip group with 1 update in the /pprxweb directory: [urllib3](https://github.com/urllib3/urllib3).


Updates `urllib3` from 2.5.0 to 2.6.3
- [Release notes](https://github.com/urllib3/urllib3/releases)
- [Changelog](https://github.com/urllib3/urllib3/blob/main/CHANGES.rst)
- [Commits](https://github.com/urllib3/urllib3/compare/2.5.0...2.6.3)

---
updated-dependencies:
- dependency-name: urllib3 dependency-version: 2.6.3 dependency-type: direct:production dependency-group: pip ...