### PR TITLE
Fix for code scanning alert: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION

In general, the fix is to explicitly define a `permissions:` block so that the `GITHUB_TOKEN` used by this workflow is restricted to only what is required. For this CI workflow, the steps only need to read the repository contents to run tests and install dependencies, so `contents: read` at minimum is appropriate.

The best way to fix this without changing existing functionality is to add a root-level `permissions:` block (so it applies to all jobs) right after the `on:` trigger block and before `jobs:`. This block should set `contents: read`, which is sufficient for `actions/checkout` and other read-only operations. No other write-scoped permissions are needed based on the shown steps. No imports or external dependencies are required for this change; it is purely a YAML configuration update inside `.github/workflows/ci.yml`.

Concretely: in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between line 7 (end of the `pull_request` branches section) and line 9 (`jobs:`). No other changes are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
